### PR TITLE
Android / Kotlin / Gradle Updates

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'org.jetbrains.kotlin.android.extensions'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '26.0.2'
+    buildToolsVersion '27.0.3'
     defaultConfig {
         applicationId "com.tolkiana.tacoapp"
         minSdkVersion 23
@@ -31,21 +31,25 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
-        exclude group: 'com.android.support', module: 'support-annotations'
-    })
+
+    implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
     implementation 'com.android.support:appcompat-v7:25.4.0'
     implementation 'com.android.support:design:25.4.0'
     implementation "com.android.support:recyclerview-v7:25.4.0"
-    testImplementation 'junit:junit:4.12'
     implementation 'com.android.support.constraint:constraint-layout:1.0.2'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.9.0'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.9.0'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.0'
-    compile 'com.fasterxml.jackson.module:jackson-module-kotlin:2.9.0'
-    compile 'com.android.volley:volley:1.0.0'
-    compile 'com.github.kittinunf.fuel:fuel:1.10.0'
-    compile 'com.github.kittinunf.fuel:fuel-android:1.10.0'
-    compile 'com.android.support:cardview-v7:25.4.0'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.9.0'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.9.0'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.0'
+    implementation 'com.fasterxml.jackson.module:jackson-module-kotlin:2.9.0'
+    implementation 'com.android.volley:volley:1.0.0'
+    implementation 'com.github.kittinunf.fuel:fuel:1.10.0'
+    implementation 'com.github.kittinunf.fuel:fuel-android:1.10.0'
+    implementation 'com.android.support:cardview-v7:25.4.0'
+
+    testImplementation 'junit:junit:4.12'
+
+    androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
+        exclude group: 'com.android.support', module: 'support-annotations'
+    })
 }

--- a/app/src/main/java/com/tolkiana/tacoapp/Product.kt
+++ b/app/src/main/java/com/tolkiana/tacoapp/Product.kt
@@ -1,5 +1,6 @@
 package com.tolkiana.tacoapp
 
+import android.annotation.SuppressLint
 import android.os.Parcelable
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import kotlinx.android.parcel.Parcelize
@@ -8,6 +9,7 @@ import kotlinx.android.parcel.Parcelize
  * Created by tolkiana on 7/11/17.
  */
 @Parcelize
+@SuppressLint("ParcelCreator")
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class Product(val code: String,
                    val name: String,

--- a/app/src/main/java/com/tolkiana/tacoapp/services/ProductsService.kt
+++ b/app/src/main/java/com/tolkiana/tacoapp/services/ProductsService.kt
@@ -1,15 +1,15 @@
 package com.tolkiana.tacoapp.services
 
 import com.github.kittinunf.fuel.httpGet
-import com.tolkiana.tacoapp.Product
 import com.github.kittinunf.result.Result
 import com.github.kittinunf.result.getAs
+import com.tolkiana.tacoapp.Product
 import com.tolkiana.tacoapp.utilities.DataParser
 
 /**
  * Created by tolkiana on 11/10/17.
  */
-class ProductsService() {
+class ProductsService {
 
     companion object {
         private const val TACO_SERVICE_URL = "https://afternoon-sea-72400.herokuapp.com"
@@ -17,12 +17,12 @@ class ProductsService() {
 
     fun fetchProductListForProductType(productType: ProductType, handler: (List<Product>) -> Unit) {
         val endpoint = TACO_SERVICE_URL + productType.path
-        endpoint.httpGet().responseString { request, response, result ->
+        endpoint.httpGet().responseString { _, _, result ->
             var tacoList = listOf<Product>()
             when (result) {
                 is Result.Success -> {
                     val json = result.getAs() ?: ""
-                    tacoList = DataParser.parseArrayFromJSON<Product>(json)
+                    tacoList = DataParser.parseArrayFromJSON(json)
                 }
             }
             handler(tacoList)

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.21'
+    ext.kotlin_version = '1.2.31'
     repositories {
         maven { url 'https://maven.google.com' }
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 09 23:19:21 EDT 2017
+#Mon Mar 26 21:39:00 EDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
This PR just updates build tools and versions from within Android Studio.

This requires Android Studio 3.1 and the latest Kotlin runtime (1.2.31). All of this should be updated through Android Studio itself.

This also solves some issues that Lint was complaining about.

